### PR TITLE
Clarify Discord token env configuration

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -1,1 +1,3 @@
-DISCORD_TOKEN=
+# Discord token used by the bot
+# Copy this file to .env for local runs, or pass it directly with `--env-file` when starting the Docker container.
+DISCORD_TOKEN=YOUR_DISCORD_BOT_TOKEN

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ pip install -r requirements.txt
 
 ```
 
-4. Rename the `.example.env` file to `.env`
+4. Rename the `.example.env` file to `.env`.
 
-5. Open the `.env` file and add your Discord bot token.
+5. Open the `.env` file and add your Discord bot token or export it as an environment variable named `DISCORD_TOKEN`.
 
 6. Run the bot:
 
@@ -55,10 +55,14 @@ docker build -t discord-disconnect-bot .
 
 ```
 
-2. Start the container using your `.env` file:
+2. Start the container using your `.env` file or pass the token directly as an environment variable:
 
 ```bash
+# Using the .env file created earlier
 docker run --env-file .env discord-disconnect-bot
+
+# Or inject the token directly at runtime
+docker run -e DISCORD_TOKEN=your_bot_token discord-disconnect-bot
 
 ```
 


### PR DESCRIPTION
## Summary
- add documentation to the example .env template for supplying the Discord token
- update README instructions to allow passing the DISCORD_TOKEN environment variable directly to the container

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d9b72dac8833289f51ed9ab056044)